### PR TITLE
New features

### DIFF
--- a/src/libs/utils.lua
+++ b/src/libs/utils.lua
@@ -98,9 +98,11 @@ function utils.checkkeys(keys, tbl)
 				errorhandler(keydata.name, "invalid key value", tbl.path)
 			end
 
-			if type(keydata.check) == "function" and
-				not keydata.check(keydata, tbl) then
-				errorhandler(keydata.name, "invalid key value", tbl.path)
+			if type(keydata.check) == "function" then
+				local valid, msg = keydata.check(keydata, tbl)
+				if not valid then
+					errorhandler(keydata.name, tostring(msg or "invalid key value"), tbl.path)
+				end
 			end
 		end
 	end

--- a/src/libs/utils.lua
+++ b/src/libs/utils.lua
@@ -88,7 +88,8 @@ end
 
 function utils.checkkeys(keys, tbl)
 	for _, keydata in ipairs(keys) do
-		if keydata.default == nil and tbl[keydata.name] == nil then
+		if keydata.default == nil and tbl[keydata.name] == nil
+		   and type(keydata.check) ~= "function" then
 			errorhandler(keydata.name, "missing required key", tbl.path)
 		elseif keydata.default ~= nil and tbl[keydata.name] == nil then
 			tbl[keydata.name] = keydata.default

--- a/src/libs/utils.lua
+++ b/src/libs/utils.lua
@@ -93,7 +93,7 @@ function utils.checkkeys(keys, tbl)
 		elseif keydata.default ~= nil and tbl[keydata.name] == nil then
 			tbl[keydata.name] = keydata.default
 		else
-			if type(tbl[keydata.name]) ~= keydata.type then
+			if keydata.type ~= nil and type(tbl[keydata.name]) ~= keydata.type then
 				errorhandler(keydata.name, "invalid key value", tbl.path)
 			end
 

--- a/src/libs/utils.lua
+++ b/src/libs/utils.lua
@@ -109,4 +109,25 @@ end
 -- return the directory seperator used for the given OS
 utils.sep = package.config:sub(1,1)
 
+-- create an iterator over a table using sorted keys
+-- order: optional, function to sort the keys with
+function utils.sortedpairs(tbl, order)
+	local index = 1
+	local keys = {}
+	for key, _ in pairs(tbl) do
+		table.insert(keys, key)
+	end
+	table.sort(keys, order)
+	local function iterator()
+		local key = keys[index]
+		if key ~= nil then
+			index = index + 1
+			return key, tbl[key]
+		else
+			return nil
+		end
+	end
+	return iterator, tbl, index
+end
+
 return utils

--- a/tests/test-utils.lua
+++ b/tests/test-utils.lua
@@ -1,0 +1,25 @@
+#!/usr/bin/lua
+require("os")
+
+local utils = require("libs.utils")
+
+local function test()
+	local test_sortedpairs = {
+        a = 1,
+        c = 3,
+        b = 2,
+        d = 4,
+    }
+    local test_sortedpairs_out = {}
+    for k, v in utils.sortedpairs(test_sortedpairs) do
+        table.insert(test_sortedpairs_out, string.format("%s = %d", k, v))
+    end
+    local test_sortedpairs_concat = table.concat(test_sortedpairs_out, ", ")
+    local test_sortedpairs_expect = "a = 1, b = 2, c = 3, d = 4"
+    assert(test_sortedpairs_concat == test_sortedpairs_expect, string.format(
+        "utils.sortedpairs iterated out of order; got: '%s', expected: '%s'",
+        test_sortedpairs_concat, test_sortedpairs_expect))
+
+	return 0
+end
+os.exit(test())


### PR DESCRIPTION
This proposes the following features:

* Make type field optional for `checkkeys`, allowing a checked key to take multiple values (it should be paired with a custom check function for validation)
* Allowing nil values in `checkkeys` when a custom check function is provided (for optional values)
* A key-sorted pairs iterator (can be used for displaying key-value maps in alphabetic order)
* Allow returning a custom error message from `checkkeys` custom check functions, providing better feedback on errors to end-users

These changes can help solve some downstream DCT issues, like allowing both numbers and string values for the `coalition` key in templates, and removing the placeholder default in the `description` field.

Concerns:
* Should the functions have a short body of documentation, including their original purposes and these changes, above them?
* Is there a situation where `checkkeys` can allow an invalid value to be passed downstream?